### PR TITLE
Quoting fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
             <version>${confluence.version}</version>

--- a/src/main/java/com/structurizr/confluence/AbstractStructurizrMacro.java
+++ b/src/main/java/com/structurizr/confluence/AbstractStructurizrMacro.java
@@ -4,11 +4,21 @@ import com.atlassian.confluence.macro.Macro;
 import com.atlassian.confluence.macro.MacroExecutionException;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public abstract class AbstractStructurizrMacro implements Macro {
 
+    private final static Pattern INVALID_HTML_ID_CHARS = Pattern.compile("[^\\dA-Za-z-_:.]");
+
     protected String createIframeId(long workspaceId, String diagramKey) {
-        return String.format("structurizrEmbedIframe_%d_%s", workspaceId, diagramKey);
+        return String.format("structurizrEmbedIframe_%d_%s", workspaceId, sanitizeElementIdPart(diagramKey));
+    }
+
+    /**
+     * Cleans up form/iframe IDs to conform with https://www.w3.org/TR/html4/types.html#type-id
+     */
+    protected String sanitizeElementIdPart(String diagramKey) {
+        return INVALID_HTML_ID_CHARS.matcher(diagramKey).replaceAll("_");
     }
 
     public Macro.BodyType getBodyType() {
@@ -19,7 +29,7 @@ public abstract class AbstractStructurizrMacro implements Macro {
         return OutputType.BLOCK;
     }
 
-    protected long getWorkspaceId(Map<String,String> parameters) throws MacroExecutionException {
+    protected long getWorkspaceId(Map<String, String> parameters) throws MacroExecutionException {
         String workspaceId = parameters.get("workspaceId");
 
         if (workspaceId == null || workspaceId.trim().length() == 0) {
@@ -36,7 +46,7 @@ public abstract class AbstractStructurizrMacro implements Macro {
         }
 
         if (structurizrUrl.endsWith("/")) {
-            structurizrUrl = structurizrUrl.substring(0, structurizrUrl.length()-1);
+            structurizrUrl = structurizrUrl.substring(0, structurizrUrl.length() - 1);
         }
 
         return structurizrUrl;

--- a/src/main/java/com/structurizr/confluence/StructurizrExpressEmbedMacro.java
+++ b/src/main/java/com/structurizr/confluence/StructurizrExpressEmbedMacro.java
@@ -13,19 +13,19 @@ public class StructurizrExpressEmbedMacro extends AbstractStructurizrMacro {
     static int COUNT = 1;
 
     private static final String TEMPLATE =
-            "<form id='%s' target='%s' method='post' action='%s/embed/express' style='display: none;'>\n" +
-            "<textarea name='definition'>%s</textarea>\n" +
-            "<input name='iframe' value='%s' />\n" +
+            "<form id=\"%s\" target=\"%s\" method=\"post\" action=\"%s/embed/express\" style=\"display: none;\">\n" +
+            "<textarea name=\"definition\">%s</textarea>\n" +
+            "<input name=\"iframe\" value=\"%s\" />\n" +
             "</form>\n" +
             "\n" +
-            "<iframe id='%s' name='%s' width='100%%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+            "<iframe id=\"%s\" name=\"%s\" width=\"100%%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
             "\n" +
-            "<script type='text/javascript'>\n" +
-            "document.getElementById('%s').submit();\n" +
+            "<script type=\"text/javascript\">\n" +
+            "document.getElementById(\"%s\").submit();\n" +
             "</script>\n" +
             "\n" +
-            "<script type='text/javascript' src='%s/static/js/structurizr-responsive-embed.js'></script>";
-    
+            "<script type=\"text/javascript\" src=\"%s/static/js/structurizr-responsive-embed.js\"></script>";
+
     public String execute(Map<String, String> parameters, String bodyContent, ConversionContext conversionContext) throws MacroExecutionException {
         String formId = "structurizrEmbedForm_Express_" + COUNT;
         String iFrameId = "structurizrEmbedIframe_Express" + COUNT;

--- a/src/main/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacro.java
+++ b/src/main/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacro.java
@@ -2,6 +2,7 @@ package com.structurizr.confluence;
 
 import com.atlassian.confluence.content.render.xhtml.ConversionContext;
 import com.atlassian.confluence.macro.MacroExecutionException;
+import com.atlassian.confluence.util.HtmlUtil;
 
 import java.util.Map;
 
@@ -36,6 +37,8 @@ public class StructurizrWorkspaceEmbedMacro extends AbstractStructurizrMacro {
             String apiKey = parameters.get("apiKey");
             String formId = createFormId(workspaceId, diagramKey);
 
+            diagramKey = HtmlUtil.htmlEncode(diagramKey);
+
             return String.format(TEMPLATE, formId, iframeId, structurizrUrl, workspaceId, apiKey, diagramKey, diagramSelector, iframeId, iframeId, iframeId, formId, structurizrUrl);
         } catch (NumberFormatException e) {
             throw new MacroExecutionException("The workspace ID must be a number.");
@@ -43,7 +46,7 @@ public class StructurizrWorkspaceEmbedMacro extends AbstractStructurizrMacro {
     }
 
     protected String createFormId(long workspaceId, String diagramKey) {
-        return String.format("structurizrEmbedForm_%d_%s", workspaceId, diagramKey);
+        return String.format("structurizrEmbedForm_%d_%s", workspaceId, sanitizeElementIdPart(diagramKey));
     }
 
 }

--- a/src/main/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacro.java
+++ b/src/main/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacro.java
@@ -11,20 +11,20 @@ import java.util.Map;
 public class StructurizrWorkspaceEmbedMacro extends AbstractStructurizrMacro {
 
     private static final String TEMPLATE =
-            "<form id='%s' target='%s' method='post' action='%s/embed/%d' style='display:none;'>\n" +
-            "<input name='apiKey' value='%s'/>\n" +
-            "<input name='diagram' value='%s' />\n" +
-            "<input name='diagramSelector' value='%s' />\n" +
-            "<input name='iframe' value='%s' />\n" +
+            "<form id=\"%s\" target=\"%s\" method=\"post\" action=\"%s/embed/%d\" style=\"display:none;\">\n" +
+            "<input name=\"apiKey\" value=\"%s\"/>\n" +
+            "<input name=\"diagram\" value=\"%s\" />\n" +
+            "<input name=\"diagramSelector\" value=\"%s\" />\n" +
+            "<input name=\"iframe\" value=\"%s\" />\n" +
             "</form>\n" +
             "\n" +
-            "<iframe id='%s' name='%s' width='100%%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+            "<iframe id=\"%s\" name=\"%s\" width=\"100%%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
             "\n" +
-            "<script type='text/javascript'>\n" +
-            "    document.getElementById('%s').submit();\n" +
+            "<script type=\"text/javascript\">\n" +
+            "    document.getElementById(\"%s\").submit();\n" +
             "</script>\n" +
             "\n" +
-            "<script type='text/javascript' src='%s/static/js/structurizr-responsive-embed.js'></script>";
+            "<script type=\"text/javascript\" src=\"%s/static/js/structurizr-responsive-embed.js\"></script>";
 
     public String execute(Map<String, String> parameters, String bodyContent, ConversionContext conversionContext) throws MacroExecutionException {
         try {

--- a/src/test/java/com/structurizr/confluence/StructurizrExpressEmbedMacroTests.java
+++ b/src/test/java/com/structurizr/confluence/StructurizrExpressEmbedMacroTests.java
@@ -26,18 +26,18 @@ public class StructurizrExpressEmbedMacroTests {
         String html = macro.execute(parameters, "A Structurizr Express definition", null);
 
         assertEquals(
-                "<form id='structurizrEmbedForm_Express_1' target='structurizrEmbedIframe_Express1' method='post' action='https://structurizr.com/embed/express' style='display: none;'>\n" +
-                        "<textarea name='definition'>A Structurizr Express definition</textarea>\n" +
-                        "<input name='iframe' value='structurizrEmbedIframe_Express1' />\n" +
+                "<form id=\"structurizrEmbedForm_Express_1\" target=\"structurizrEmbedIframe_Express1\" method=\"post\" action=\"https://structurizr.com/embed/express\" style=\"display: none;\">\n" +
+                        "<textarea name=\"definition\">A Structurizr Express definition</textarea>\n" +
+                        "<input name=\"iframe\" value=\"structurizrEmbedIframe_Express1\" />\n" +
                         "</form>\n" +
                         "\n" +
-                        "<iframe id='structurizrEmbedIframe_Express1' name='structurizrEmbedIframe_Express1' width='100%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+                        "<iframe id=\"structurizrEmbedIframe_Express1\" name=\"structurizrEmbedIframe_Express1\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
                         "\n" +
-                        "<script type='text/javascript'>\n" +
-                        "document.getElementById('structurizrEmbedForm_Express_1').submit();\n" +
+                        "<script type=\"text/javascript\">\n" +
+                        "document.getElementById(\"structurizrEmbedForm_Express_1\").submit();\n" +
                         "</script>\n" +
                         "\n" +
-                        "<script type='text/javascript' src='https://structurizr.com/static/js/structurizr-responsive-embed.js'></script>", html);
+                        "<script type=\"text/javascript\" src=\"https://structurizr.com/static/js/structurizr-responsive-embed.js\"></script>", html);
     }
 
 }

--- a/src/test/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacroTests.java
+++ b/src/test/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacroTests.java
@@ -51,23 +51,23 @@ public class StructurizrWorkspaceEmbedMacroTests {
         parameters.put("structurizrUrl", "https://structurizr.com");
         parameters.put("workspaceId", "1234");
         parameters.put("apiKey", "d4d56ad3-2b23-4fd5-bea0-cf3879368f2e");
-        parameters.put("diagramKey", "Context");
+        parameters.put("diagramKey", "Diagram 'Key with special & characters");
         parameters.put("diagramSelector", "true");
 
         String html = macro.execute(parameters, "", null);
 
         assertEquals(
-                "<form id=\"structurizrEmbedForm_1234_Context\" target=\"structurizrEmbedIframe_1234_Context\" method=\"post\" action=\"https://structurizr.com/embed/1234\" style=\"display:none;\">\n" +
+                "<form id=\"structurizrEmbedForm_1234_Diagram__Key_with_special___characters\" target=\"structurizrEmbedIframe_1234_Diagram__Key_with_special___characters\" method=\"post\" action=\"https://structurizr.com/embed/1234\" style=\"display:none;\">\n" +
                 "<input name=\"apiKey\" value=\"d4d56ad3-2b23-4fd5-bea0-cf3879368f2e\"/>\n" +
-                "<input name=\"diagram\" value=\"Context\" />\n" +
+                "<input name=\"diagram\" value=\"Diagram &#39;Key with special &amp; characters\" />\n" +
                 "<input name=\"diagramSelector\" value=\"true\" />\n" +
-                "<input name=\"iframe\" value=\"structurizrEmbedIframe_1234_Context\" />\n" +
+                "<input name=\"iframe\" value=\"structurizrEmbedIframe_1234_Diagram__Key_with_special___characters\" />\n" +
                 "</form>\n" +
                 "\n" +
-                "<iframe id=\"structurizrEmbedIframe_1234_Context\" name=\"structurizrEmbedIframe_1234_Context\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
+                "<iframe id=\"structurizrEmbedIframe_1234_Diagram__Key_with_special___characters\" name=\"structurizrEmbedIframe_1234_Diagram__Key_with_special___characters\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
                 "\n" +
                 "<script type=\"text/javascript\">\n" +
-                "    document.getElementById(\"structurizrEmbedForm_1234_Context\").submit();\n" +
+                "    document.getElementById(\"structurizrEmbedForm_1234_Diagram__Key_with_special___characters\").submit();\n" +
                 "</script>\n" +
                 "\n" +
                 "<script type=\"text/javascript\" src=\"https://structurizr.com/static/js/structurizr-responsive-embed.js\"></script>", html);

--- a/src/test/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacroTests.java
+++ b/src/test/java/com/structurizr/confluence/StructurizrWorkspaceEmbedMacroTests.java
@@ -57,20 +57,20 @@ public class StructurizrWorkspaceEmbedMacroTests {
         String html = macro.execute(parameters, "", null);
 
         assertEquals(
-                "<form id='structurizrEmbedForm_1234_Context' target='structurizrEmbedIframe_1234_Context' method='post' action='https://structurizr.com/embed/1234' style='display:none;'>\n" +
-                "<input name='apiKey' value='d4d56ad3-2b23-4fd5-bea0-cf3879368f2e'/>\n" +
-                "<input name='diagram' value='Context' />\n" +
-                "<input name='diagramSelector' value='true' />\n" +
-                "<input name='iframe' value='structurizrEmbedIframe_1234_Context' />\n" +
+                "<form id=\"structurizrEmbedForm_1234_Context\" target=\"structurizrEmbedIframe_1234_Context\" method=\"post\" action=\"https://structurizr.com/embed/1234\" style=\"display:none;\">\n" +
+                "<input name=\"apiKey\" value=\"d4d56ad3-2b23-4fd5-bea0-cf3879368f2e\"/>\n" +
+                "<input name=\"diagram\" value=\"Context\" />\n" +
+                "<input name=\"diagramSelector\" value=\"true\" />\n" +
+                "<input name=\"iframe\" value=\"structurizrEmbedIframe_1234_Context\" />\n" +
                 "</form>\n" +
                 "\n" +
-                "<iframe id='structurizrEmbedIframe_1234_Context' name='structurizrEmbedIframe_1234_Context' width='100%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+                "<iframe id=\"structurizrEmbedIframe_1234_Context\" name=\"structurizrEmbedIframe_1234_Context\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
                 "\n" +
-                "<script type='text/javascript'>\n" +
-                "    document.getElementById('structurizrEmbedForm_1234_Context').submit();\n" +
+                "<script type=\"text/javascript\">\n" +
+                "    document.getElementById(\"structurizrEmbedForm_1234_Context\").submit();\n" +
                 "</script>\n" +
                 "\n" +
-                "<script type='text/javascript' src='https://structurizr.com/static/js/structurizr-responsive-embed.js'></script>", html);
+                "<script type=\"text/javascript\" src=\"https://structurizr.com/static/js/structurizr-responsive-embed.js\"></script>", html);
     }
 
     @Test
@@ -84,20 +84,20 @@ public class StructurizrWorkspaceEmbedMacroTests {
         String html = macro.execute(parameters, "", null);
 
         assertEquals(
-                "<form id='structurizrEmbedForm_1234_1' target='structurizrEmbedIframe_1234_1' method='post' action='https://structurizr.com/embed/1234' style='display:none;'>\n" +
-                "<input name='apiKey' value='d4d56ad3-2b23-4fd5-bea0-cf3879368f2e'/>\n" +
-                "<input name='diagram' value='1' />\n" +
-                "<input name='diagramSelector' value='true' />\n" +
-                "<input name='iframe' value='structurizrEmbedIframe_1234_1' />\n" +
+                "<form id=\"structurizrEmbedForm_1234_1\" target=\"structurizrEmbedIframe_1234_1\" method=\"post\" action=\"https://structurizr.com/embed/1234\" style=\"display:none;\">\n" +
+                "<input name=\"apiKey\" value=\"d4d56ad3-2b23-4fd5-bea0-cf3879368f2e\"/>\n" +
+                "<input name=\"diagram\" value=\"1\" />\n" +
+                "<input name=\"diagramSelector\" value=\"true\" />\n" +
+                "<input name=\"iframe\" value=\"structurizrEmbedIframe_1234_1\" />\n" +
                 "</form>\n" +
                 "\n" +
-                "<iframe id='structurizrEmbedIframe_1234_1' name='structurizrEmbedIframe_1234_1' width='100%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+                "<iframe id=\"structurizrEmbedIframe_1234_1\" name=\"structurizrEmbedIframe_1234_1\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
                 "\n" +
-                "<script type='text/javascript'>\n" +
-                "    document.getElementById('structurizrEmbedForm_1234_1').submit();\n" +
+                "<script type=\"text/javascript\">\n" +
+                "    document.getElementById(\"structurizrEmbedForm_1234_1\").submit();\n" +
                 "</script>\n" +
                 "\n" +
-                "<script type='text/javascript' src='https://structurizr.com/static/js/structurizr-responsive-embed.js'></script>", html);
+                "<script type=\"text/javascript\" src=\"https://structurizr.com/static/js/structurizr-responsive-embed.js\"></script>", html);
     }
 
     @Test
@@ -111,20 +111,20 @@ public class StructurizrWorkspaceEmbedMacroTests {
         String html = macro.execute(parameters, "", null);
 
         assertEquals(
-                "<form id='structurizrEmbedForm_1234_Context' target='structurizrEmbedIframe_1234_Context' method='post' action='https://structurizr.com/embed/1234' style='display:none;'>\n" +
-                "<input name='apiKey' value='d4d56ad3-2b23-4fd5-bea0-cf3879368f2e'/>\n" +
-                "<input name='diagram' value='Context' />\n" +
-                "<input name='diagramSelector' value='false' />\n" +
-                "<input name='iframe' value='structurizrEmbedIframe_1234_Context' />\n" +
+                "<form id=\"structurizrEmbedForm_1234_Context\" target=\"structurizrEmbedIframe_1234_Context\" method=\"post\" action=\"https://structurizr.com/embed/1234\" style=\"display:none;\">\n" +
+                "<input name=\"apiKey\" value=\"d4d56ad3-2b23-4fd5-bea0-cf3879368f2e\"/>\n" +
+                "<input name=\"diagram\" value=\"Context\" />\n" +
+                "<input name=\"diagramSelector\" value=\"false\" />\n" +
+                "<input name=\"iframe\" value=\"structurizrEmbedIframe_1234_Context\" />\n" +
                 "</form>\n" +
                 "\n" +
-                "<iframe id='structurizrEmbedIframe_1234_Context' name='structurizrEmbedIframe_1234_Context' width='100%' marginwidth='0' marginheight='0' frameborder='0' scrolling='no' allowfullscreen='true'></iframe>\n" +
+                "<iframe id=\"structurizrEmbedIframe_1234_Context\" name=\"structurizrEmbedIframe_1234_Context\" width=\"100%\" marginwidth=\"0\" marginheight=\"0\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"true\"></iframe>\n" +
                 "\n" +
-                "<script type='text/javascript'>\n" +
-                "    document.getElementById('structurizrEmbedForm_1234_Context').submit();\n" +
+                "<script type=\"text/javascript\">\n" +
+                "    document.getElementById(\"structurizrEmbedForm_1234_Context\").submit();\n" +
                 "</script>\n" +
                 "\n" +
-                "<script type='text/javascript' src='https://structurizr.com/static/js/structurizr-responsive-embed.js'></script>", html);
+                "<script type=\"text/javascript\" src=\"https://structurizr.com/static/js/structurizr-responsive-embed.js\"></script>", html);
     }
 
 }


### PR DESCRIPTION
Fixes some quoting/escaping issues:

- HTML element IDs are now cleaned up to conform with the HTML 4 spec.
  Actually, in our internal fork of the plugin, we're simply using UUIDs for the 
  element IDs, but I didn't want to change the existing logic too much as I guess
  some users might rely on reproducible IDs being generated.
- The diagram key attribute value is HTML-escaped to avoid issues with invalid
  characters in diagram keys.
- The generated HTML consistently uses double quotes. This avoids issues with single
  quotes in diagram keys.